### PR TITLE
also require cargo tool to be installed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 Alien-Rust-*
+/.build

--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{$dist->name}},
 
 {{$NEXT}}
+  - Also require cargo tool for system install
 
 0.01      2023-02-14 04:38:00-05:00 America/New_York
   - initial version

--- a/alienfile
+++ b/alienfile
@@ -9,6 +9,13 @@ plugin 'Probe::CommandLine' => (
   version => qr/^rustc ([0-9\.]+)/,
 );
 
+plugin 'Probe::CommandLine' => (
+  command   => 'cargo',
+  args      => [ '--version' ],
+  match     => qr/^cargo [0-9\.]+/,
+  secondary => 1,
+);
+
 share {
   my $rustup;
   if( $^O ne 'MSWin32' ) {

--- a/dist.ini
+++ b/dist.ini
@@ -18,6 +18,7 @@ Alien::Build = 2.70
 [AlienBuild]
 [CheckChangesHasContent]
 [GithubMeta]
+issues = 1
 [ReadmeAnyFromPod]
 type = markdown
 location = root

--- a/t/alien_rust.t
+++ b/t/alien_rust.t
@@ -18,4 +18,8 @@ if( Alien::Rust->install_type eq 'share' ) {
    ->success
    ->out_like(qr/^rustc ([0-9\.]+)/);
 
+ run_ok([ qw(cargo --version) ])
+   ->success
+   ->out_like(qr/^cargo [0-9\.]+/);
+
 done_testing;


### PR DESCRIPTION
TL;DR the `cargo` tool is what you typically actually need rather than the lower level `rustc`.

https://github.com/PerlFFI/FFI-Platypus-Lang-Rust/issues/39#issuecomment-1430046531

also adding GitHub as the issue tracker.